### PR TITLE
feat: add types for datagolf topX responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+#API KEYS
+#Datagolf
+DG_TOKEN=
+DISCORD_TOKEN=

--- a/d.ts
+++ b/d.ts
@@ -1,0 +1,19 @@
+type BookOffering = "bet365" | "betfair" | "betmgm" | "betway" | "bovada" | "caesars" | "draftkings" | "fanduel" | "pointsbet" | "unibet" | "williamhill";
+
+interface OddsEntry extends Record<BookOffering, string> {
+	dg_id: number;
+	datagolf: {
+		baseline: null | string;
+		baseline_history_fit: string;
+	};
+	player_name: string;
+}
+
+export interface DatagolfResponse {
+	books_offering: BookOffering[];
+	event_name: string;
+	last_updated: string; // ISO date string
+	market: string;
+	notes: string;
+	odds: OddsEntry[];
+}

--- a/exampletop10.js
+++ b/exampletop10.js
@@ -1,3 +1,5 @@
+/** @typedef {import('./d.ts').DatagolfResponse} TopX
+/** @type {TopX} */
 let top10 = {
   books_offering: [
     "bet365",

--- a/exampletop20.js
+++ b/exampletop20.js
@@ -1,3 +1,5 @@
+/** @typedef {import('./d.ts').DatagolfResponse} TopX
+/** @type {TopX} */
 let top20 = {
   books_offering: [
     "bet365",

--- a/exampletop5.js
+++ b/exampletop5.js
@@ -1,3 +1,5 @@
+/** @typedef {import('./d.ts').DatagolfResponse} TopX
+/** @type {TopX} */
 let top5 = {
   books_offering: [
     "bet365",

--- a/examplewin.js
+++ b/examplewin.js
@@ -1,3 +1,5 @@
+/** @typedef {import('./d.ts').DatagolfResponse} DatagolfResponse
+/** @type {DatagolfResponse} */
 let win = {
   books_offering: [
     "bet365",


### PR DESCRIPTION
Created a typescript file baseline for you (you can export/import these into regular javascript files, to get IDE intellisense). 


For now anywhere that you use top5, top10, top20, will give you intellisense. 



